### PR TITLE
Add preserve_attributes option

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -21,6 +21,7 @@ module Paperclip
         :interpolator          => Paperclip::Interpolations,
         :only_process          => [],
         :path                  => ":rails_root/public:url",
+        :preserve_attributes   => false,
         :preserve_files        => false,
         :processors            => [:thumbnail],
         :source_file_options   => {},
@@ -557,12 +558,14 @@ module Paperclip
           path(style) if exists?(style)
         end.compact
       end
-      instance_write(:file_name, nil)
-      instance_write(:content_type, nil)
-      instance_write(:file_size, nil)
-      instance_write(:fingerprint, nil)
-      instance_write(:created_at, nil) if has_enabled_but_unset_created_at?
-      instance_write(:updated_at, nil)
+      unless @options[:preserve_attributes]
+        instance_write(:file_name, nil)
+        instance_write(:content_type, nil)
+        instance_write(:file_size, nil)
+        instance_write(:fingerprint, nil)
+        instance_write(:created_at, nil) if has_enabled_but_unset_created_at?
+        instance_write(:updated_at, nil)
+      end
     end
 
     def flush_errors #:nodoc:


### PR DESCRIPTION
https://blinker.tpondemand.com/entity/4473

Before, lines 560-565 were firing for all deletes, even if `preserve_files` is set to true. This meant that, after a soft-deletion, the S3 object would still exist, but the local data needed to determine the hash and URL for that object would be destroyed.

This change adds a new option `preserve_attributes` which can be additionally set, so as to not destroy this data. 

Note: Adding a new option was chosen instead of making `preserve_files` apply to these lines so that other attachments would retain the same behavior as before (principle of least surprise).

Also Note: The CircleCI build failure can be disregarded, as we have no meaningful specs on this repo.